### PR TITLE
Add refresh button to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@ li.task.due .date-badge, li.task.over .date-badge, li.task.done .date-badge{ bor
 .btn:focus-visible{ outline:2px solid var(--brand); outline-offset:2px; }
 .btn.primary{ background:var(--brand); color:#fff; border-color:var(--brand) }
 .btn-danger{ background:#E5484D; color:#fff; border-color:#E5484D }
+.btn.icon{ padding:6px; min-height:32px; display:flex; align-items:center; justify-content:center; }
 .empty{ padding:24px; text-align:center; color:var(--text); opacity:.9; font-size:var(--fs-2) }
 
 /* Forms */
@@ -248,6 +249,7 @@ textarea{ min-height:80px; resize:vertical }
 </head>
 <body>
 <header>
+  <button id="refreshBtn" class="btn icon" aria-label="Aggiorna pagina">⟳</button>
   <img id="appLogo" class="logo" alt="Logo">
   <h1 id="appTitle">Pulizie di Casa</h1>
   <span class="user-pill" id="userPill">
@@ -555,6 +557,18 @@ function relLum({r,g,b}){ const s=[r,g,b].map(v=>{ v/=255; return v<=0.03928? v/
 function byId(id){ return document.getElementById(id); }
 const logoEl=byId("appLogo");
 const avatarEl=byId("avatar"), whoEl=byId("who");
+const refreshBtn = byId("refreshBtn");
+if(refreshBtn){
+  refreshBtn.addEventListener("click", () => {
+    if("caches" in window){
+      caches.keys()
+        .then(keys => Promise.all(keys.map(k => caches.delete(k))))
+        .finally(() => location.reload(true));
+    }else{
+      location.reload(true);
+    }
+  });
+}
 function activeUser(){ return state.users.find(u=>u.id===state.activeUserId) || state.users[0]; }
 function setActiveUser(id){ state.activeUserId=id; save(); renderHeader(); renderAssigneeSelects(); renderUsersList(); renderLeader(); renderHistory(); }
 


### PR DESCRIPTION
## Summary
- add refresh button next to logo
- style button for compact icon appearance
- clear caches and force page reload when pressed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a487eff0088320a73b326bae583909