### PR TITLE
feat: implement PWA auto-update flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <title>Pulizie di Casa</title>
-<link rel="manifest" href="/manifest.json">
+<link rel="manifest" href="/manifest.json?v=1">
 <link rel="apple-touch-icon" href="icons/apple-touch-icon-180.png">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -1537,11 +1537,9 @@ function boot(){
   // calcola lo spazio per evitare il "taglio" in fondo
   adaptBottomInset();
 
-  if("serviceWorker" in navigator){
-    addEventListener("load", ()=> navigator.serviceWorker.register("./service-worker.js").catch(()=>{}) );
-  }
 }
 boot();
 </script>
+<script src="main.js?v=1"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,45 @@
+const BUILD_HASH = "1";
+
+function showUpdateToast() {
+  if (document.getElementById("updateToast")) return;
+  const t = document.createElement("div");
+  t.id = "updateToast";
+  t.className = "toast";
+  t.textContent = "Aggiornamento disponibile ";
+  const btn = document.createElement("button");
+  btn.textContent = "Aggiorna";
+  btn.className = "btn";
+  btn.addEventListener("click", () => {
+    if (navigator.serviceWorker.controller) {
+      navigator.serviceWorker.controller.postMessage({ type: "SKIP_WAITING" });
+    }
+    t.remove();
+  });
+  t.appendChild(btn);
+  toastWrap.appendChild(t);
+}
+
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register(`/service-worker.js?v=${BUILD_HASH}`)
+    .then(reg => {
+      reg.addEventListener("updatefound", () => {
+        const sw = reg.installing;
+        if (!sw) return;
+        sw.addEventListener("statechange", () => {
+          if (sw.state === "installed" && navigator.serviceWorker.controller) {
+            showUpdateToast();
+          }
+        });
+      });
+    });
+
+  navigator.serviceWorker.addEventListener("message", (evt) => {
+    if (evt.data?.type === "SW_UPDATE_AVAILABLE") {
+      showUpdateToast();
+    }
+    if (evt.data?.type === "RELOAD_PAGE") {
+      window.location.reload();
+    }
+  });
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Cometa Cleaner",
   "short_name": "ComClean",
   "description": "Lista condivisa per le pulizie di casa. Offline, senza server.",
-  "start_url": ".",
+  "start_url": "./?v=1",
   "display": "standalone",
   "prefer_related_applications": false,
   "background_color": "#ffffff",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,8 +1,10 @@
-const CACHE_NAME = "pulizie-cache-v4";
+const BUILD_HASH = "1";
+const CACHE_NAME = `app-cache-v${BUILD_HASH}`;
 const ASSETS = [
   "./",
   "./index.html",
-  "./manifest.json",
+  `./manifest.json?v=${BUILD_HASH}`,
+  `./main.js?v=${BUILD_HASH}`,
   "./icons/icon-192.png",
   "./icons/icon-512.png",
   "./icons/icon-maskable-512.png",
@@ -18,23 +20,48 @@ self.addEventListener("install", (event) => {
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.map(k => (k !== CACHE_NAME ? caches.delete(k) : null)))
-    )
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => k === CACHE_NAME ? null : caches.delete(k)));
+      await self.clients.claim();
+      const clients = await self.clients.matchAll({ type: "window" });
+      clients.forEach(c => c.postMessage({ type: "SW_UPDATE_AVAILABLE" }));
+    })()
   );
-  self.clients.claim();
+});
+
+self.addEventListener("message", (evt) => {
+  if (evt.data?.type === "SKIP_WAITING") {
+    self.skipWaiting();
+    self.clients.matchAll({ type: "window" }).then(clients => {
+      clients.forEach(c => c.postMessage({ type: "RELOAD_PAGE" }));
+    });
+  }
 });
 
 self.addEventListener("fetch", (event) => {
   const req = event.request;
   if (req.method !== "GET") return;
 
+  if (req.mode === "navigate" || (req.headers.get("accept") || "").includes("text/html")) {
+    event.respondWith(
+      fetch(req)
+        .then(res => {
+          const copy = res.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(req, copy));
+          return res;
+        })
+        .catch(() => caches.match(req))
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(req).then(cached => {
       if (cached) return cached;
       return fetch(req).then(res => {
-        const resClone = res.clone();
-        caches.open(CACHE_NAME).then(cache => cache.put(req, resClone));
+        const copy = res.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(req, copy));
         return res;
       }).catch(() => cached);
     })
@@ -46,9 +73,9 @@ self.addEventListener("notificationclick", function(event) {
   event.waitUntil(
     clients.matchAll({ type: "window", includeUncontrolled: true }).then(clientList => {
       for (const client of clientList) {
-        if ('focus' in client) return client.focus();
+        if ("focus" in client) return client.focus();
       }
-      if (clients.openWindow) return clients.openWindow('./');
+      if (clients.openWindow) return clients.openWindow("./");
     })
   );
 });


### PR DESCRIPTION
## Summary
- version caches and implement network-first strategy for HTML
- add SW messaging for update and reload
- register service worker with update toast and skip-waiting trigger

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49bf529f4832092a852698caf3f1b