### PR TITLE
fix(settings): remove extra separator line

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,9 @@ li.task.due .date-badge, li.task.over .date-badge, li.task.done .date-badge{ bor
 .empty{ padding:24px; text-align:center; color:var(--text); opacity:.9; font-size:var(--fs-2) }
 
 /* Forms */
-.grid{ display:grid; grid-template-columns:1fr 1fr; gap:10px } .grid .full{ grid-column:1/-1 }
+.grid{ display:grid; grid-template-columns:1fr 1fr; gap:10px }
+.grid .full{ grid-column:1/-1 }
+.add-row{ margin-top:10px; padding-top:10px; border-top:1px solid var(--border); }
   codex/update-app-ui-with-pastel-themes
 input, select, textarea{ padding:12px; border:1px solid var(--border); border-radius:8px; background:var(--card); color:var(--text); font-size:var(--fs-2) }
 textarea{ min-height:80px; resize:vertical }
@@ -386,8 +388,7 @@ textarea{ min-height:80px; resize:vertical }
       <details>
         <summary>Gestione utenti</summary>
         <div id="usersList" class="grid" style="margin-top:10px"></div>
-        <hr>
-        <div class="grid">
+        <div class="grid add-row">
           <input id="u-name" placeholder="Nome utente">
           <select id="u-color"></select>
           <label class="btn">Foto utente <input id="u-photo" type="file" accept="image/*" style="display:none"></label>
@@ -397,8 +398,7 @@ textarea{ min-height:80px; resize:vertical }
       <details>
         <summary>Stanze</summary>
         <div class="grid" id="roomsList" style="margin-top:10px"></div>
-        <hr>
-        <div class="grid">
+        <div class="grid add-row">
           <input id="r-name" placeholder="Nuova stanza">
           <label class="btn">Foto stanza <input id="r-photo" type="file" accept="image/*" style="display:none"></label>
           <button id="r-add" class="btn primary">Aggiungi stanza</button>


### PR DESCRIPTION
## Summary
- remove stray `<hr>` separators in user and room settings lists
- style insertion rows with `.add-row` to provide consistent spacing and border

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a082ac748320b7327c6882187db9