### PR TITLE
feat: add theme selector and remove background

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,26 +7,64 @@
 <link rel="manifest" href="/manifest.json">
 <link rel="apple-touch-icon" href="icons/apple-touch-icon-180.png">
 <meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="apple-mobile-web-app-status-bar-style" content="black">
+<meta name="apple-mobile-web-app-status-bar-style" content="default">
 <meta name="apple-mobile-web-app-title" content="Sappylo">
-<meta name="theme-color" content="#000000">
+<meta name="theme-color" content="#F8F5FF">
 <style>
 :root{
-  --brand:#A0C4FF; --brand-2:#B9FBC0;
-  --bg:#F8F5FF; --card:#FFFFFF; --text:#2D2D2D; --muted:#6B7280; --border:#E5E7EB;
+  --color-primary:#A0C4FF;
+  --color-secondary:#B9FBC0;
+  --color-bg-light:#F8F5FF;
+  --color-bg:var(--color-bg-light);
+  --color-surface:#FFFFFF;
+  --color-text:#2D2D2D;
+  --color-muted:#6B7280;
+  --color-border:#E5E7EB;
   --shadow:0 1px 3px rgba(0,0,0,.08);
   --radius:12px; --fs-1:18px; --fs-2:16px; --fs-3:14px;
   --c-future:#FFFFFF; --c-future-text:#2D2D2D;
   --c-due:#FFF3B0; --c-due-text:#2D2D2D;
   --c-over:#FFB3C1; --c-over-text:#2D2D2D;
   --c-done:#B9FBC0; --c-done-text:#2D2D2D;
-  --bottom-nav-h: 80px; /* viene aggiornato da JS */
+  --bottom-nav-h:80px; /* viene aggiornato da JS */
 }
 @media (prefers-color-scheme: dark){
   :root{
-    --bg:#1E1E1E; --card:#2B2B2B; --text:#F9FAFB; --muted:#9CA3AF; --border:#3F3F46; --shadow:0 1px 3px rgba(0,0,0,.5);
-    --c-future:#2B2B2B; --c-future-text:#F9FAFB; --c-due:#665C00; --c-due-text:#F9FAFB; --c-over:#7F1D1D; --c-over-text:#F9FAFB; --c-done:#065F46; --c-done-text:#F9FAFB;
+    --color-bg:#1E1E1E;
+    --color-surface:#2B2B2B;
+    --color-text:#F9FAFB;
+    --color-muted:#9CA3AF;
+    --color-border:#3F3F46;
+    --shadow:0 1px 3px rgba(0,0,0,.5);
+    --c-future:#2B2B2B; --c-future-text:#F9FAFB;
+    --c-due:#665C00; --c-due-text:#F9FAFB;
+    --c-over:#7F1D1D; --c-over-text:#F9FAFB;
+    --c-done:#065F46; --c-done-text:#F9FAFB;
   }
+}
+html[data-theme="light"]{
+  --color-bg:var(--color-bg-light);
+  --color-surface:#FFFFFF;
+  --color-text:#2D2D2D;
+  --color-muted:#6B7280;
+  --color-border:#E5E7EB;
+  --shadow:0 1px 3px rgba(0,0,0,.08);
+  --c-future:#FFFFFF; --c-future-text:#2D2D2D;
+  --c-due:#FFF3B0; --c-due-text:#2D2D2D;
+  --c-over:#FFB3C1; --c-over-text:#2D2D2D;
+  --c-done:#B9FBC0; --c-done-text:#2D2D2D;
+}
+html[data-theme="dark"]{
+  --color-bg:#1E1E1E;
+  --color-surface:#2B2B2B;
+  --color-text:#F9FAFB;
+  --color-muted:#9CA3AF;
+  --color-border:#3F3F46;
+  --shadow:0 1px 3px rgba(0,0,0,.5);
+  --c-future:#2B2B2B; --c-future-text:#F9FAFB;
+  --c-due:#665C00; --c-due-text:#F9FAFB;
+  --c-over:#7F1D1D; --c-over-text:#F9FAFB;
+  --c-done:#065F46; --c-done-text:#F9FAFB;
 }
 @media (display-mode: standalone){
   /* rifiniture per PWA installata */
@@ -46,24 +84,21 @@ html{
   scroll-padding-bottom:calc(var(--bottom-nav-h) + env(safe-area-inset-bottom));
 }
 body{
-  background:var(--bg);
-  color:var(--text);
+  background:var(--color-bg);
+  color:var(--color-text);
   line-height:1.45;
 }
 header{
   position:sticky; top:0; z-index:30;
-  background:var(--card);
+  background:var(--color-surface);
   box-shadow:var(--shadow);
   padding:calc(10px + env(safe-area-inset-top)) 12px 10px;
   display:flex; align-items:center; gap:10px;
 }
-@media (prefers-color-scheme: dark){
-  header{ background:var(--card); }
-}
 header h1{font-size:var(--fs-1); margin:0; flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
-.logo{width:26px;height:26px;border-radius:6px;object-fit:cover;border:1px solid var(--border); background:var(--brand);}
-.user-pill{display:flex; align-items:center; gap:8px; border:1px solid var(--border); padding:6px 10px; border-radius:999px; background:var(--brand-2);}
-.avatar{width:20px; height:20px; border-radius:50%; object-fit:cover; background:var(--brand-2);}
+.logo{width:26px;height:26px;border-radius:6px;object-fit:cover;border:1px solid var(--color-border); background:var(--color-primary);}
+.user-pill{display:flex; align-items:center; gap:8px; border:1px solid var(--color-border); padding:6px 10px; border-radius:999px; background:var(--color-secondary);}
+.avatar{width:20px; height:20px; border-radius:50%; object-fit:cover; background:var(--color-secondary);}
 .app-shell{
   min-height:100dvh;
   height:calc(var(--vh, 1vh) * 100);
@@ -89,11 +124,11 @@ ul#list:empty{display:none;}
 
 /* Tabs (Da Fare) */
 .tabs{display:flex; gap:8px; margin:6px 0 10px}
-.tab{flex:0 0 auto; padding:8px 12px; border-radius:999px; border:1px solid var(--border); background:var(--card); font-weight:700; cursor:pointer}
-.tab.active{ background:var(--brand); color:var(--text); border-color:var(--brand);}
+.tab{flex:0 0 auto; padding:8px 12px; border-radius:999px; border:1px solid var(--color-border); background:var(--color-surface); font-weight:700; cursor:pointer}
+.tab.active{ background:var(--color-primary); color:var(--color-text); border-color:var(--color-primary);}
 
 /* Lista pulizie */
-li.task{ margin:10px 0; border-radius:12px; border:1px solid var(--border); box-shadow:var(--shadow); overflow:hidden; cursor:pointer; }
+li.task{ margin:10px 0; border-radius:12px; border:1px solid var(--color-border); box-shadow:var(--shadow); overflow:hidden; cursor:pointer; }
 .task-head{ display:flex; align-items:center; gap:10px; padding:12px 14px; }
 .chk input{ width:26px; height:26px; }
 .head-main{ flex:1; min-width:0; }
@@ -115,32 +150,32 @@ li.task.due .date-badge, li.task.over .date-badge, li.task.done .date-badge{ bor
 .badges span{ font-size:11px; padding:4px 8px; border-radius:999px; border:1px solid rgba(0,0,0,.15); background:rgba(255,255,255,.25); }
 .assignee-me{ background:rgba(37,99,235,.2)!important; } .assignee-partner{ background:rgba(225,29,72,.2)!important; }
 .actions{ display:flex; gap:8px; margin-top:10px; flex-wrap:wrap }
-.btn{ padding:10px 12px; border:1px solid var(--border); border-radius:8px; background:var(--card); color:var(--text); cursor:pointer; min-height:44px; }
-.btn:focus-visible{ outline:2px solid var(--brand); outline-offset:2px; }
-.btn.primary{ background:var(--brand); color:var(--text); border-color:var(--brand) }
-.btn.secondary{ background:var(--brand-2); color:var(--text); border-color:var(--brand-2) }
-.btn-danger{ background:#FFB3C1; color:var(--text); border-color:#FFB3C1 }
+.btn{ padding:10px 12px; border:1px solid var(--color-border); border-radius:8px; background:var(--color-surface); color:var(--color-text); cursor:pointer; min-height:44px; }
+.btn:focus-visible{ outline:2px solid var(--color-primary); outline-offset:2px; }
+.btn.primary{ background:var(--color-primary); color:var(--color-text); border-color:var(--color-primary) }
+.btn.secondary{ background:var(--color-secondary); color:var(--color-text); border-color:var(--color-secondary) }
+.btn-danger{ background:#FFB3C1; color:var(--color-text); border-color:#FFB3C1 }
 .btn.icon{ padding:6px; min-height:32px; display:flex; align-items:center; justify-content:center; }
-.empty{ padding:24px; text-align:center; color:var(--text); opacity:.9; font-size:var(--fs-2) }
+.empty{ padding:24px; text-align:center; color:var(--color-text); opacity:.9; font-size:var(--fs-2) }
 
 /* Forms */
 .grid{ display:grid; grid-template-columns:1fr 1fr; gap:10px }
 .grid .full{ grid-column:1/-1 }
-.add-row{ margin-top:10px; padding-top:10px; border-top:1px solid var(--border); }
+.add-row{ margin-top:10px; padding-top:10px; border-top:1px solid var(--color-border); }
   codex/update-app-ui-with-pastel-themes
-input, select, textarea{ padding:12px; border:1px solid var(--border); border-radius:8px; background:var(--card); color:var(--text); font-size:var(--fs-2) }
+input, select, textarea{ padding:12px; border:1px solid var(--color-border); border-radius:8px; background:var(--color-surface); color:var(--color-text); font-size:var(--fs-2) }
 textarea{ min-height:80px; resize:vertical }
 .toggle{
   appearance:none;
   width:44px;
   height:24px;
-  background:var(--border);
+  background:var(--color-border);
   border-radius:12px;
   position:relative;
   cursor:pointer;
   border:none;
 }
-.toggle:focus-visible{outline:2px solid var(--brand); outline-offset:2px;}
+.toggle:focus-visible{outline:2px solid var(--color-primary); outline-offset:2px;}
 .toggle::before{
   content:"";
   position:absolute;
@@ -150,32 +185,32 @@ textarea{ min-height:80px; resize:vertical }
   border-radius:50%;
   transition:transform .2s;
 }
-.toggle:checked{ background:var(--brand); }
+.toggle:checked{ background:var(--color-primary); }
 .toggle:checked::before{ transform:translateX(20px); }
 .weekdays{ display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; }
 .weekdays label{ display:flex; align-items:center; gap:4px; }
-.photo-zone{ border:2px dashed var(--border); border-radius:12px; padding:20px; text-align:center; cursor:pointer; }
+.photo-zone{ border:2px dashed var(--color-border); border-radius:12px; padding:20px; text-align:center; cursor:pointer; }
 .photo-zone.hover{ background:#f3f7ff; }
 .photo-preview{ position:relative; margin-top:10px; display:none; }
-.photo-preview img{ width:100px; height:100px; object-fit:cover; border-radius:12px; border:1px solid var(--border); }
+.photo-preview img{ width:100px; height:100px; object-fit:cover; border-radius:12px; border:1px solid var(--color-border); }
 .photo-preview button{ position:absolute; top:4px; right:4px; }
 
-.filter-box{background:var(--card);border:1px solid var(--border);border-radius:16px;padding:16px;}
+.filter-box{background:var(--color-surface);border:1px solid var(--color-border);border-radius:16px;padding:16px;}
 .filter-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;}
 .filter-grid .full{grid-column:1/-1;}
 .filter-box label{font-weight:600;font-size:var(--fs-2);display:flex;flex-direction:column;gap:4px;}
-.filter-box label.check{flex-direction:row;align-items:center;min-height:44px;padding:4px 8px;border:1px solid var(--border);border-radius:12px;}
+.filter-box label.check{flex-direction:row;align-items:center;min-height:44px;padding:4px 8px;border:1px solid var(--color-border);border-radius:12px;}
 .filter-actions{display:flex;gap:12px;justify-content:flex-end;margin-top:16px;}
 @media(max-width:480px){.filter-grid{grid-template-columns:1fr;}}
 
 /* Bottom nav */
 .bottom-nav{
-  position:fixed; left:0; right:0; bottom:0; z-index:40; background:var(--card); border-top:1px solid var(--border); box-shadow:0 -1px 2px rgba(0,0,0,.05);
+  position:fixed; left:0; right:0; bottom:0; z-index:40; background:var(--color-surface); border-top:1px solid var(--color-border); box-shadow:0 -1px 2px rgba(0,0,0,.05);
   padding:8px max(12px, env(safe-area-inset-left)) calc(8px + env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-right)); display:flex; gap:10px; justify-content:space-around;
 }
-.tabbtn{ flex:1; padding:10px 12px; border-radius:14px; border:1px solid var(--border); background:var(--card); font-weight:700; cursor:pointer; min-height:44px;}
-.tabbtn:focus-visible{ outline:2px solid var(--brand); outline-offset:2px; }
-.tabbtn.active{ border-color:var(--brand); color:var(--text); background:var(--brand) }
+.tabbtn{ flex:1; padding:10px 12px; border-radius:14px; border:1px solid var(--color-border); background:var(--color-surface); font-weight:700; cursor:pointer; min-height:44px;}
+.tabbtn:focus-visible{ outline:2px solid var(--color-primary); outline-offset:2px; }
+.tabbtn.active{ border-color:var(--color-primary); color:var(--color-text); background:var(--color-primary) }
 
 /* Sheet editor: overlay alto, copre calendario */
 .sheet{
@@ -183,11 +218,11 @@ textarea{ min-height:80px; resize:vertical }
   left:0; right:0; top:clamp(56px, 8svh, 120px); top:clamp(56px, 8dvh, 120px); bottom:0;
   width:100%; max-height:calc(100svh - clamp(56px, 8svh, 120px)); max-height:calc(100dvh - clamp(56px, 8dvh, 120px));
   padding-top:env(safe-area-inset-top);
-  background:var(--card); border:1px solid var(--border);
+  background:var(--color-surface); border:1px solid var(--color-border);
   border-radius:12px 12px 0 0; box-shadow:0 -4px 16px rgba(0,0,0,.1);
   display:none; overflow-y:auto;
 }
-.sheet header{ position:sticky; top:0; background:var(--card); padding:calc(12px + env(safe-area-inset-top)) 16px 12px; display:flex; align-items:center; gap:10px; border-bottom:1px solid var(--border); }
+.sheet header{ position:sticky; top:0; background:var(--color-surface); padding:calc(12px + env(safe-area-inset-top)) 16px 12px; display:flex; align-items:center; gap:10px; border-bottom:1px solid var(--color-border); }
 .sheet .content{ padding:12px 16px calc(16px + env(safe-area-inset-bottom)); }
 
 /* Task full-screen view */
@@ -195,7 +230,7 @@ textarea{ min-height:80px; resize:vertical }
   position:fixed;
   inset:0;
   z-index:6000;
-  background:var(--card);
+  background:var(--color-surface);
   display:none;
   flex-direction:column;
 }
@@ -204,7 +239,7 @@ textarea{ min-height:80px; resize:vertical }
   align-items:center;
   gap:10px;
   padding:calc(12px + env(safe-area-inset-top)) 16px 12px;
-  border-bottom:1px solid var(--border);
+  border-bottom:1px solid var(--color-border);
 }
 .task-view .content{
   flex:1;
@@ -220,16 +255,16 @@ textarea{ min-height:80px; resize:vertical }
 .task-view .photos img{
   width:100%;
   border-radius:12px;
-  border:1px solid var(--border);
+  border:1px solid var(--color-border);
   object-fit:cover;
 }
 
 /* Classifica */
 .leader{ display:grid; gap:10px; }
-.row{ display:flex; align-items:center; gap:10px; background:var(--card); border:1px solid var(--border); padding:10px; border-radius:12px; box-shadow:var(--shadow); flex-wrap:wrap; overflow:hidden }
+.row{ display:flex; align-items:center; gap:10px; background:var(--color-surface); border:1px solid var(--color-border); padding:10px; border-radius:12px; box-shadow:var(--shadow); flex-wrap:wrap; overflow:hidden }
 .row .pts{ margin-left:auto; font-weight:800 }
 .history{ margin-top:12px; }
-.event{ display:flex; gap:10px; align-items:center; border:1px dashed var(--border); background:var(--card); padding:8px 10px; border-radius:12px; margin:6px 0; }
+.event{ display:flex; gap:10px; align-items:center; border:1px dashed var(--color-border); background:var(--color-surface); padding:8px 10px; border-radius:12px; margin:6px 0; }
 .delta{ font-weight:800; }
 .delta.pos{ color:#117733 } .delta.neg{ color:#B00020 }
 
@@ -248,9 +283,9 @@ textarea{ min-height:80px; resize:vertical }
 .btn.block{ width:100%; }
 .file-btn{
   display:inline-flex; align-items:center; justify-content:center; gap:8px;
-  padding:12px; border:1px solid var(--border); border-radius:8px;
-  background:var(--brand-2); cursor:pointer; text-align:center; font-weight:600;
-  color:var(--text);
+  padding:12px; border:1px solid var(--color-border); border-radius:8px;
+  background:var(--color-secondary); cursor:pointer; text-align:center; font-weight:600;
+  color:var(--color-text);
 }
 .file-btn input[type="file"]{ display:none; }
 .small-note{ font-size:12px; opacity:.7; margin-top:8px; }
@@ -261,13 +296,7 @@ textarea{ min-height:80px; resize:vertical }
   bottom:calc(var(--bottom-nav-h, 80px) + env(safe-area-inset-bottom) + 8px);
   z-index:200; display:flex; flex-direction:column; gap:8px; align-items:center;
 }
-.toast{ background:#111827; color:#fff; padding:10px 14px; border-radius:12px; box-shadow:0 4px 12px rgba(0,0,0,.25); font-weight:600; max-width:90vw; }
-@media (prefers-color-scheme: light){ .toast{ background:#1f2937; } }
-
-/* Overlay leggibilità su sfondo */
-#viewTasks{ position:relative; }
-#viewTasks[data-hasbg="1"]::before{ content:""; position:absolute; inset:0; background: var(--bg-overlay, rgba(0,0,0,.28)); pointer-events:none; z-index:0; }
-#viewTasks > *{ position:relative; z-index:1; }
+.toast{ background:var(--color-text); color:var(--color-bg); padding:10px 14px; border-radius:12px; box-shadow:0 4px 12px rgba(0,0,0,.25); font-weight:600; max-width:90vw; }
 
 /* Drawer filtri (alto-destra, mobile-friendly) */
 .drawer{ position:fixed; inset:0; z-index:150; display:none; }
@@ -277,8 +306,8 @@ textarea{ min-height:80px; resize:vertical }
   position:absolute; right:0; top:0; bottom:auto;
   width:min(420px, 92vw);
   max-height:86svh; max-height:86dvh;
-  background:var(--card);
-  border-left:1px solid var(--border);
+  background:var(--color-surface);
+  border-left:1px solid var(--color-border);
   box-shadow:var(--shadow);
   transform:translateY(-100%);
   transition:transform .24s ease;
@@ -301,12 +330,12 @@ textarea{ min-height:80px; resize:vertical }
 .cal-grid{ display:grid; grid-template-columns:repeat(7,1fr); gap:6px; }
 .cal-dow{ text-align:center; font-weight:700; font-size:12px; opacity:.8; padding:6px 0; }
 .cal-cell{
-  background:var(--card); border:1px solid var(--border); border-radius:10px; padding:8px; min-height:64px; position:relative;
+  background:var(--color-surface); border:1px solid var(--color-border); border-radius:10px; padding:8px; min-height:64px; position:relative;
   display:flex; flex-direction:column; gap:6px; box-shadow:var(--shadow);
 }
 .cal-daynum{ font-weight:800; font-size:12px; opacity:.9; }
 .cal-badge{
-  position:absolute; top:8px; right:8px; font-size:11px; padding:3px 6px; border-radius:999px; border:1px solid var(--border); background:var(--brand-2);
+  position:absolute; top:8px; right:8px; font-size:11px; padding:3px 6px; border-radius:999px; border:1px solid var(--color-border); background:var(--color-secondary);
 }
 .cal-cell.muted{ opacity:.55; }
 .cal-list{ margin-top:12px; }
@@ -314,10 +343,10 @@ textarea{ min-height:80px; resize:vertical }
 
 /* Accordion moderno (Impostazioni, un solo open alla volta) */
 .accordion details{
-  border:1px solid var(--border);
+  border:1px solid var(--color-border);
   border-radius:12px;
   margin:10px 0;
-  background:var(--card);
+  background:var(--color-surface);
   box-shadow:var(--shadow);
   overflow:hidden;
 }
@@ -330,9 +359,9 @@ textarea{ min-height:80px; resize:vertical }
 }
 .accordion summary::-webkit-details-marker{ display:none; }
 .accordion details[open] summary{
-  background:var(--brand);
-  color:var(--text);
-  border-bottom:1px solid var(--border);
+  background:var(--color-primary);
+  color:var(--color-text);
+  border-bottom:1px solid var(--color-border);
 }
 .accordion details > *:not(summary){ padding:12px 14px; }
 </style>
@@ -350,7 +379,7 @@ textarea{ min-height:80px; resize:vertical }
 
 <main class="container">
   <!-- VIEW: DA FARE -->
-  <section id="viewTasks" class="view active" style="background-size:cover;background-position:center">
+  <section id="viewTasks" class="view active">
     <div class="tabs">
       <button class="tab active" data-scope="oggi">Oggi</button>
       <button class="tab" data-scope="tutte">Tutte</button>
@@ -424,11 +453,13 @@ textarea{ min-height:80px; resize:vertical }
             <strong>Palette app</strong>
             <div id="appPalettes" style="display:flex;flex-wrap:wrap;gap:8px;margin-top:8px"></div>
           </div>
-          <div class="full">
-            <strong>Sfondo sezione “Pulizie”</strong>
-            <label class="btn">Carica sfondo <input id="bgTasksFile" type="file" accept="image/*" style="display:none"></label>
-            <button id="bgTasksClear" class="btn">Rimuovi sfondo</button>
-          </div>
+          <label class="field full">Tema
+            <select id="themeSelect">
+              <option value="system">Sistema</option>
+              <option value="light">Chiaro</option>
+              <option value="dark">Scuro</option>
+            </select>
+          </label>
         </div>
       </details>
       <details>
@@ -637,13 +668,13 @@ const APP_PALETTES=[
 ];
 
 const defaults={
-  version:10,
+  version:11,
   users:[
     {id:"me", name:"Alberto", color:"#A0C4FF", photo:null},
     {id:"partner", name:"Giorgia", color:"#FF8FA3", photo:null}
   ],
   activeUserId:"me",
-  appearance:{ palette:APP_PALETTES[0], bgTasks:null, logo:null },
+  appearance:{ palette:APP_PALETTES[0], logo:null, theme:"system" },
   settings:{
     remindAt:"09:00",
     resurfaceUnfinished:false,
@@ -661,6 +692,10 @@ function migrate(d){
   if(!('lastMalusDate' in d)) d.lastMalusDate=null;
   if(!d.users || Array.isArray(d.users)===false){ d.users = defaults.users; d.activeUserId="me"; }
   if(!d.appearance) d.appearance = defaults.appearance;
+  else{
+    if('bgTasks' in d.appearance) delete d.appearance.bgTasks;
+    if(!d.appearance.theme) d.appearance.theme="system";
+  }
   return d;
 }
 function load(){
@@ -679,10 +714,6 @@ function showToast(msg, timeout=2200){
   setTimeout(()=>{ t.style.opacity="0"; t.style.transition="opacity .3s"; }, timeout);
   setTimeout(()=>{ toastWrap.removeChild(t); }, timeout+350);
 }
-
-/* Helpers colore/contrasto */
-function hexToRgb(h){ const x=h.replace("#",""); const b=parseInt(x.length===3? x.split("").map(c=>c+c).join("") : x,16); return {r:(b>>16)&255, g:(b>>8)&255, b:b&255}; }
-function relLum({r,g,b}){ const s=[r,g,b].map(v=>{ v/=255; return v<=0.03928? v/12.92 : Math.pow((v+0.055)/1.055,2.4); }); return 0.2126*s[0]+0.7152*s[1]+0.0722*s[2]; }
 
 /* ===== Util/UI ===== */
 function byId(id){ return document.getElementById(id); }
@@ -705,47 +736,31 @@ function setActiveUser(id){ state.activeUserId=id; save(); renderHeader(); rende
 
 /* Palette */
 function applyPalette(p){
-  document.documentElement.style.setProperty("--brand", p.brand);
-  document.documentElement.style.setProperty("--brand-2", p.brand2);
-  document.documentElement.style.setProperty("--bg", p.bg);
-  document.querySelector('meta[name="theme-color"]').setAttribute('content', p.brand);
-  const L = relLum(hexToRgb(p.bg));
-  const darkBg = L < 0.5;
-  if(darkBg){
-    document.documentElement.style.setProperty("--text", "#ECF2FF");
-    document.documentElement.style.setProperty("--card", "#12182A");
-    document.documentElement.style.setProperty("--border", "#1E2640");
-    document.documentElement.style.setProperty("--c-future", "#12182A");
-    document.documentElement.style.setProperty("--c-future-text", "#ECF2FF");
-  }else{
-    document.documentElement.style.setProperty("--text", "#0D1321");
-    document.documentElement.style.setProperty("--card", "#FFFFFF");
-    document.documentElement.style.setProperty("--border", "#E3E8F5");
-    document.documentElement.style.setProperty("--c-future", "#FFFFFF");
-    document.documentElement.style.setProperty("--c-future-text", "#0D1321");
-  }
+  document.documentElement.style.setProperty("--color-primary", p.brand);
+  document.documentElement.style.setProperty("--color-secondary", p.brand2);
+  document.documentElement.style.setProperty("--color-bg-light", p.bg);
 }
 
-/* Header, logo, sfondo */
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+function applyTheme(){
+  const t = state.appearance.theme || 'system';
+  if(t === 'system') document.documentElement.removeAttribute('data-theme');
+  else document.documentElement.setAttribute('data-theme', t);
+  const bg = getComputedStyle(document.documentElement).getPropertyValue('--color-bg').trim();
+  document.querySelector('meta[name="theme-color"]').setAttribute('content', bg);
+  const statusMeta=document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]');
+  if(statusMeta){ statusMeta.setAttribute('content', (t==='dark' || (t==='system' && prefersDark.matches)) ? 'black' : 'default'); }
+}
+prefersDark.addEventListener('change', ()=>{ if(state.appearance.theme==='system') applyTheme(); });
+
+/* Header e logo */
 function renderHeader(){
   const u=activeUser();
   whoEl.textContent=u?.name||"Utente";
   if(u?.photo){ avatarEl.src=u.photo; avatarEl.style.background="transparent"; }
   else { avatarEl.removeAttribute("src"); avatarEl.style.background=u?.color||"#ccc"; }
   logoEl.src = state.appearance.logo || "icons/icon-192.png";
-  logoEl.style.background="var(--brand)";
-  const viewTasks=document.getElementById("viewTasks");
-  if(state.appearance.bgTasks){
-    viewTasks.style.backgroundImage = `url(${state.appearance.bgTasks})`;
-    viewTasks.setAttribute("data-hasbg","1");
-    const L = relLum(hexToRgb(getComputedStyle(document.documentElement).getPropertyValue("--bg").trim()));
-    const overlay = L < 0.5 ? "rgba(255,255,255,.22)" : "rgba(0,0,0,.28)";
-    document.documentElement.style.setProperty("--bg-overlay", overlay);
-  }else{
-    viewTasks.style.backgroundImage = "none";
-    viewTasks.removeAttribute("data-hasbg");
-    document.documentElement.style.removeProperty("--bg-overlay");
-  }
+  logoEl.style.background="var(--color-primary)";
 }
 
 /* ===== Date helpers (gg-mm-aa) ===== */
@@ -1331,7 +1346,7 @@ rAdd.addEventListener("click", async ()=>{
 });
 
 /* ===== Aspetto ===== */
-const appPalettesEl=byId("appPalettes"), bgTasksFile=byId("bgTasksFile"), bgTasksClear=byId("bgTasksClear");
+const appPalettesEl=byId("appPalettes"), themeSelect=byId("themeSelect");
 function renderAppPalettes(){
   appPalettesEl.innerHTML="";
   APP_PALETTES.forEach(p=>{
@@ -1339,12 +1354,12 @@ function renderAppPalettes(){
     b.className="btn"; b.textContent=p.name;
     b.style.background=p.brand;
     b.style.borderColor=p.brand;
-    b.addEventListener("click", ()=>{ state.appearance.palette=p; save(); applyPalette(p); renderHeader(); showToast("🎨 Palette applicata"); });
+    b.addEventListener("click", ()=>{ state.appearance.palette=p; save(); applyPalette(p); applyTheme(); renderHeader(); showToast("🎨 Palette applicata"); });
     appPalettesEl.appendChild(b);
   });
 }
-bgTasksFile.addEventListener("change", async (e)=>{ const f=e.target.files[0]; if(!f) return; state.appearance.bgTasks=await fileToDataURL(f); save(); renderHeader(); showToast("🖼️ Sfondo impostato"); e.target.value=""; });
-bgTasksClear.addEventListener("click", ()=>{ state.appearance.bgTasks=null; save(); renderHeader(); showToast("Sfondo rimosso"); });
+themeSelect.value = state.appearance.theme || "system";
+themeSelect.addEventListener("change", e=>{ state.appearance.theme=e.target.value; save(); applyTheme(); });
 
 /* ===== Notifiche & Backup ===== */
 byId("enableNotifs").addEventListener("click", requestNotifs);
@@ -1488,7 +1503,7 @@ function renderCalendarDayList(d){
     .map(t=>{
       const desc = t.notes ? ` • ${t.notes}` : "";
       const hasPhotos = t.photo ? ' • 📷1' : '';
-      return `<li class="task future" style="list-style:none; margin:8px 0; padding:10px; border-radius:10px; border:1px solid var(--border);">
+      return `<li class="task future" style="list-style:none; margin:8px 0; padding:10px; border-radius:10px; border:1px solid var(--color-border);">
   <div style="display:flex; gap:8px; align-items:center;">
     <div class="head-main" style="flex:1; min-width:0;">
       <div class="title">${t.title||t.name}</div>
@@ -1559,6 +1574,7 @@ document.fonts && document.fonts.ready && document.fonts.ready.then(adaptBottomI
 /* ===== Boot ===== */
 function boot(){
   applyPalette(state.appearance.palette||APP_PALETTES[3]);
+  applyTheme();
   renderHeader();
   renderRoomSelect(); renderAssigneeSelects();
   renderUsersList(); renderRooms();

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const BUILD_HASH = "1";
+const BUILD_HASH = "2";
 
 function showUpdateToast() {
   if (document.getElementById("updateToast")) return;

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "display": "standalone",
   "prefer_related_applications": false,
   "background_color": "#FFFFFF",
-  "theme_color": "#000000",
+  "theme_color": "#F8F5FF",
   "icons": [
     { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
     { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" },

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const BUILD_HASH = "1";
+const BUILD_HASH = "2";
 const CACHE_NAME = `app-cache-v${BUILD_HASH}`;
 const ASSETS = [
   "./",


### PR DESCRIPTION
## Summary
- remove obsolete background upload UI and logic
- add system-aware light/dark theme with user override
- refactor styling to use color tokens and update PWA meta

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a48ae5c8832081efe8287a452670