### PR TITLE
fix: secondo tentativo risoluzione bug critico

### DIFF
--- a/docs/bugreport.md
+++ b/docs/bugreport.md
@@ -1,0 +1,47 @@
+# Bug Report: PWA broken on load
+
+## Reproduction Steps
+1. Servire la cartella con `python3 -m http.server 8000`.
+2. Aprire `http://localhost:8000/` in un browser (riproduzione qui tramite Node).
+
+## Osservati
+- Il JS inline in `index.html` non viene eseguito; la console mostra un errore di sintassi.
+- Esecuzione dello script con Node:
+```
+$ node -e "..."
+Parse error: Unexpected token 'for'
+```
+
+## Regression
+- L'errore appare dopo le merge `codex/*` (vedi `git log`).
+
+## Solution
+- Rimosse righe residue `codex/*` in `index.html` che provocavano un `SyntaxError` in fase di parsing.
+- Aggiornato il riferimento a `main.js?v=2` per sincronizzare la cache del Service Worker.
+
+## Nuovo stato dopo fix
+- L'app continua a non avviarsi su ambienti privi di `structuredClone`.
+- Esecuzione del JS mostra:
+  ```
+  ReferenceError: structuredClone is not defined
+  ```
+
+## Soluzione
+- Aggiunto polyfill per `structuredClone` in `index.html` per garantire compatibilità con browser meno recenti.
+
+## Come Testare
+1. Avviare `python3 -m http.server 8000`.
+2. Aprire `http://localhost:8000/` in un browser.
+3. Verificare che l'app carichi senza errori in console.
+4. Per replicare il vecchio errore:
+   ```
+   node - <<'NODE'
+   const fs=require('fs');
+   const vm=require('vm');
+   const script=fs.readFileSync('index.html','utf8').match(/<script>([\s\S]*?)<\/script>/)[1];
+   const sandbox={navigator:{},localStorage:{getItem:()=>null,setItem:()=>{}},document:{getElementById:()=>({})}}; sandbox.window=sandbox;
+   vm.createContext(sandbox);
+   try{ vm.runInContext(script,sandbox); console.log('ok'); }catch(e){ console.error(e); }
+   NODE
+   ```
+   L'output non deve contenere `ReferenceError: structuredClone is not defined`.

--- a/index.html
+++ b/index.html
@@ -72,23 +72,19 @@ html[data-theme="dark"]{
 *{box-sizing:border-box}
 img{max-width:100%;height:auto;}
 html,body{
-codex/improve-full-screen-mode-for-pwa-l9vpxf
   overscroll-behavior:none;
   overscroll-behavior-y:none;
 }
 body{
-codex/remove-background-section-and-add-dark-mode
   background:var(--color-bg);
   color:var(--color-text);
 
   line-height:1.45;
-codex/improve-full-screen-mode-for-pwa-l9vpxf
 
 }
 html{
   scroll-padding-top:calc(56px + env(safe-area-inset-top));
   scroll-padding-bottom:calc(var(--bottom-nav-h) + env(safe-area-inset-bottom));
-codex/improve-full-screen-mode-for-pwa-l9vpxf
 }
 header{
   position:sticky; top:0; z-index:30;
@@ -164,7 +160,6 @@ li.task.due .date-badge, li.task.over .date-badge, li.task.done .date-badge{ bor
 .grid{ display:grid; grid-template-columns:1fr 1fr; gap:10px }
 .grid .full{ grid-column:1/-1 }
 .add-row{ margin-top:10px; padding-top:10px; border-top:1px solid var(--color-border); }
-  codex/update-app-ui-with-pastel-themes
 input, select, textarea{ padding:12px; border:1px solid var(--color-border); border-radius:8px; background:var(--color-surface); color:var(--color-text); font-size:var(--fs-2) }
 textarea{ min-height:80px; resize:vertical }
 .toggle{
@@ -641,6 +636,9 @@ textarea{ min-height:80px; resize:vertical }
 </div>
 
   <script>
+if(typeof structuredClone!=="function"){
+  window.structuredClone=obj=>JSON.parse(JSON.stringify(obj));
+}
 /* ===== Stato & storage ===== */
 const DBKEY="pulizie-db-v10";
 const nowISO=()=>new Date().toISOString();
@@ -1547,7 +1545,6 @@ function setVH(){
 }
 function updateBodyScroll(){
   const vh = window.visualViewport ? visualViewport.height : window.innerHeight;
-codex/improve-full-screen-mode-for-pwa-l9vpxf
   const shell = document.querySelector('.app-shell');
   const ch = shell ? shell.scrollHeight : document.body.scrollHeight;
   const val = ch <= vh ? 'hidden' : 'auto';
@@ -1597,6 +1594,6 @@ function boot(){
 }
 boot();
 </script>
-<script src="main.js?v=1"></script>
+<script src="main.js?v=2"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add polyfill for `structuredClone` to ensure app boots on older browsers
- document reproduction and fix in bug report

## Testing
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
const script=fs.readFileSync('index.html','utf8').match(/<script>([\s\S]*?)<\/script>/)[1];
const sandbox={navigator:{},localStorage:{getItem:()=>null,setItem:()=>{}},document:{getElementById:()=>({})}}; sandbox.window=sandbox;
vm.createContext(sandbox);
try{ vm.runInContext(script,sandbox); console.log('ok'); }catch(e){ console.error(e); }
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a4a8f9e1088320b2f69767fb693743