### PR TITLE
feat: add accessible sticky navigation tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,11 @@
   --icon-on-bg: var(--text-color);
   --icon-on-surface: var(--text-color);
   --btn-icon-color: var(--icon-on-surface);
+  --nav-bg: var(--surface-color);
+  --nav-fg: var(--text-color);
+  --nav-fg-active: var(--accent-color);
+  --nav-indicator: var(--accent-color);
+  --nav-height: 56px;
 }
 @media (prefers-color-scheme: dark){
   :root{
@@ -62,7 +67,7 @@ html,body{
   min-height:100dvh; /* evita tagli su mobile con barra URL dinamica */
 }
 html{
-  scroll-padding-top:calc(56px + var(--safe-top));
+  scroll-padding-top:var(--nav-height);
   scroll-padding-bottom:var(--safe-bottom);
 }
 body{
@@ -74,16 +79,31 @@ body{
 }
 header{
   position:sticky; top:0; z-index:30;
-  background:var(--surface-color);
+  background:var(--nav-bg);
   box-shadow:var(--shadow);
-  padding:calc(10px + var(--safe-top)) 12px 10px;
+}
+header .top-bar{
   display:flex; align-items:center; gap:10px;
+  padding:calc(10px + var(--safe-top)) 12px 10px;
 }
 header h1{font-size:var(--fs-1); margin:0; flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
 .logo{width:26px;height:26px;border-radius:6px;object-fit:cover;border:1px solid var(--border-color); background:var(--accent-color);}
 .user-pill{display:flex; align-items:center; gap:8px; border:1px solid var(--border-color); padding:6px 10px; border-radius:999px; background:var(--accent-color-2);}
 .avatar{width:20px; height:20px; border-radius:50%; object-fit:cover; background:var(--accent-color-2);}
-.container{max-width:860px; margin:0 auto; padding:12px; display:flex; flex-direction:column; min-height:calc(100svh - (56px + var(--safe-top))); min-height:calc(100dvh - (56px + var(--safe-top)));}
+.nav-tabs{position:relative; display:flex; overflow-x:auto; scroll-snap-type:x mandatory; background:var(--nav-bg); color:var(--nav-fg);}
+.nav-tabs::-webkit-scrollbar{display:none;}
+.nav-tabs::before,.nav-tabs::after{content:""; position:absolute; top:0; bottom:0; width:12px; pointer-events:none;}
+.nav-tabs::before{left:0; background:linear-gradient(to right,var(--nav-bg),transparent);}
+.nav-tabs::after{right:0; background:linear-gradient(to left,var(--nav-bg),transparent);}
+.nav-tab{position:relative; flex:0 0 auto; display:flex; align-items:center; gap:8px; padding:0 16px; min-height:56px; font-size:16px; font-weight:500; line-height:1.3; background:none; border:none; color:inherit; cursor:pointer; scroll-snap-align:start;}
+.nav-tab .icon{width:20px; height:20px; flex:0 0 20px;}
+.nav-tab:focus-visible{outline:2px solid var(--nav-indicator); outline-offset:2px;}
+.nav-tab:active{background:var(--accent-color-2);}
+.nav-tab.active{color:var(--nav-fg-active);}
+.nav-tab.active::after{content:""; position:absolute; left:12px; right:12px; bottom:0; height:2px; background:var(--nav-indicator); border-radius:2px;}
+@media(max-width:359px){.nav-tab{padding:0 10px; font-size:14px;}}
+@media(min-width:600px){.nav-tab{flex:1; justify-content:center;}}
+.container{max-width:860px; margin:0 auto; padding:12px; display:flex; flex-direction:column; min-height:calc(100svh - var(--nav-height)); min-height:calc(100dvh - var(--nav-height));}
 .view{display:none; flex-direction:column; flex:1;}
 .view.active{display:flex;}
 #viewTasks{min-height:0;}
@@ -129,13 +149,6 @@ li.task.due .date-badge, li.task.over .date-badge, li.task.done .date-badge{ bor
 .icon-btn:hover{ background:var(--accent-color-2); border-radius:6px; }
 .icon-btn:active{ background:var(--accent-color); color:var(--icon-on-bg); }
 .icon-btn:focus-visible{ outline:2px solid var(--accent-color); outline-offset:2px; }
-.fab{ position:fixed; bottom:calc(16px + var(--safe-bottom)); right:calc(16px + env(safe-area-inset-right)); width:56px; height:56px; border-radius:50%; background:var(--accent-color); color:var(--icon-on-bg); display:flex; align-items:center; justify-content:center; box-shadow:var(--shadow); border:none; cursor:pointer; }
-.fab:focus-visible{ outline:2px solid var(--accent-color-2); outline-offset:2px; }
-.menu-overlay{ position:fixed; inset:0; z-index:50; background:rgba(0,0,0,.4); display:none; padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left); }
-.menu-overlay.open{ display:flex; align-items:center; justify-content:center; }
-.menu-panel{ background:var(--surface-color); padding:20px; border-radius:12px; display:flex; flex-direction:column; gap:10px; box-shadow:var(--shadow); }
-.menu-item{ width:100%; }
-.menu-item.active{ --btn-bg-color:var(--accent-color); background:var(--btn-bg-color); color:var(--btn-text-color); border-color:var(--accent-color); }
 .loader{ position:fixed; inset:0; z-index:100; background:var(--bg-color); display:none; align-items:center; justify-content:center; padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left); }
 .loader.is-active{ display:flex; }
 .loader-logo{ width:72px; height:72px; animation:spin 1.2s linear infinite; }
@@ -353,19 +366,39 @@ input::placeholder, textarea::placeholder{ color:var(--placeholder-color); }
 </style>
 </head>
 <body>
-<header>
-  <img id="appLogo" class="logo" alt="Logo">
-  <h1 id="appTitle">Pulizie di Casa</h1>
-  <button id="toggleFilters" class="icon-btn" aria-label="Apri filtri" role="button">
-    <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 4h18l-7 8v6l-4 2v-8z"/></svg>
-  </button>
-  <button id="addTaskBtn" class="icon-btn" aria-label="Nuova pulizia">
-    <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
-  </button>
-  <span class="user-pill" id="userPill">
-    <img id="avatar" class="avatar" alt="">
-    <strong id="who">Utente</strong>
-  </span>
+<header id="appHeader">
+  <div class="top-bar">
+    <img id="appLogo" class="logo" alt="Logo">
+    <h1 id="appTitle">Pulizie di Casa</h1>
+    <button id="toggleFilters" class="icon-btn" aria-label="Apri filtri" role="button">
+      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 4h18l-7 8v6l-4 2v-8z"/></svg>
+    </button>
+    <button id="addTaskBtn" class="icon-btn" aria-label="Nuova pulizia">
+      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+    </button>
+    <span class="user-pill" id="userPill">
+      <img id="avatar" class="avatar" alt="">
+      <strong id="who">Utente</strong>
+    </span>
+  </div>
+  <nav id="mainNav" class="nav-tabs" role="tablist">
+    <button class="nav-tab active" data-tab="tasks" role="tab" aria-selected="true">
+      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 4h16v16H4z"/><path d="M8 8h8M8 12h8M8 16h8"/></svg>
+      <span>Pulizie</span>
+    </button>
+    <button class="nav-tab" data-tab="calendar" role="tab" aria-selected="false">
+      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 4h18v18H3z"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
+      <span>Calendario</span>
+    </button>
+    <button class="nav-tab" data-tab="rank" role="tab" aria-selected="false">
+      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M7 21v-8M12 21V3M17 21v-5"/></svg>
+      <span>Classifica</span>
+    </button>
+    <button class="nav-tab" data-tab="settings" role="tab" aria-selected="false">
+      <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9c0 .69.4 1.3 1.01 1.58.61.28 1.32.04 1.69-.53a2 2 0 1 1 3.46 2.07 1.65 1.65 0 0 0-.1 1.35c.17.67.24 1.37.2 2.05a2 2 0 1 1-3.46 2.07 1.65 1.65 0 0 0-.1-1.35A1.65 1.65 0 0 0 19.4 15z"/></svg>
+      <span>Impostazioni</span>
+    </button>
+  </nav>
 </header>
 
 <main class="container">
@@ -488,19 +521,6 @@ input::placeholder, textarea::placeholder{ color:var(--placeholder-color); }
     </div>
   </section>
 </main>
-
-<button id="menuFab" class="fab" aria-label="Apri menù">
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
-</button>
-
-<div id="menuOverlay" class="menu-overlay" aria-hidden="true">
-  <div class="menu-panel" role="menu" aria-modal="true">
-    <button class="btn menu-item" data-tab="tasks" role="menuitem">Pulizie</button>
-    <button class="btn menu-item" data-tab="calendar" role="menuitem">Calendario</button>
-    <button class="btn menu-item" data-tab="rank" role="menuitem">Classifica</button>
-    <button class="btn menu-item" data-tab="settings" role="menuitem">Impostazioni</button>
-  </div>
-</div>
 
 <div id="loaderOverlay" class="loader" aria-hidden="true">
   <img src="icons/icon-192.png" alt="" class="loader-logo">
@@ -789,7 +809,7 @@ function updateTextContrast(){
   const text=bestTextColor(bg);
   root.style.setProperty('--text-color', text);
   root.style.setProperty('--placeholder-color', text==='#000000'? 'rgba(0,0,0,0.6)':'rgba(255,255,255,0.6)');
-  document.querySelectorAll('.btn, .tab.active, .menu-item.active').forEach(el=>{
+  document.querySelectorAll('.btn, .tab.active, .nav-tab.active').forEach(el=>{
     const bgc=getComputedStyle(el).getPropertyValue('--btn-bg-color').trim()||bg;
     el.style.setProperty('--btn-text-color', bestTextColor(bgc));
   });
@@ -1520,43 +1540,48 @@ byId("clearDone").addEventListener("click", ()=>{ state.tasks=state.tasks.filter
 /* ===== Navigazione Menù ===== */
 const viewTasks=byId("viewTasks"), viewCalendar=byId("viewCalendar"), viewRank=byId("viewRank"), viewSettings=byId("viewSettings");
 let currentTab="tasks";
-const menuOverlay=byId("menuOverlay"), menuFab=byId("menuFab");
-const menuItems=document.querySelectorAll(".menu-item");
+const navTabs=document.querySelectorAll('.nav-tab');
 
-function openMenu(){
-  menuOverlay.classList.add("open");
-  menuOverlay.removeAttribute("aria-hidden");
-  const active=Array.from(menuItems).find(i=>i.dataset.tab===currentTab);
-  menuItems.forEach(i=>i.classList.toggle("active", i===active));
-  (active||menuItems[0]).focus();
+function updateNav(tab){
+  navTabs.forEach(b=>{
+    const active=b.dataset.tab===tab;
+    b.classList.toggle('active',active);
+    b.setAttribute('aria-selected',active);
+    b.setAttribute('tabindex',active?'0':'-1');
+  });
 }
-function closeMenu(){
-  menuOverlay.classList.remove("open");
-  menuOverlay.setAttribute("aria-hidden","true");
-  menuFab.focus();
-}
-menuFab.addEventListener("click", openMenu);
-menuOverlay.addEventListener("click", e=>{ if(e.target===menuOverlay) closeMenu(); });
-menuOverlay.addEventListener("keydown", e=>{
-  if(e.key==="Escape") return closeMenu();
-  if(e.key==="Tab"){
-    const f=Array.from(menuOverlay.querySelectorAll('button'));
-    const first=f[0]; const last=f[f.length-1];
-    if(e.shiftKey && document.activeElement===first){ e.preventDefault(); last.focus(); }
-    else if(!e.shiftKey && document.activeElement===last){ e.preventDefault(); first.focus(); }
-  }
-});
+
+updateNav(currentTab);
 
 function switchView(tab){
-  [viewTasks,viewCalendar,viewRank,viewSettings].forEach(v=>v.classList.remove("active"));
-  if(tab==="tasks"){ viewTasks.classList.add("active"); byId("appTitle").textContent="Pulizie di Casa"; }
-  if(tab==="calendar"){ viewCalendar.classList.add("active"); byId("appTitle").textContent="Calendario Pulizie"; renderCalendar(); }
-  if(tab==="rank"){ viewRank.classList.add("active"); byId("appTitle").textContent="Classifica"; renderLeader(); renderHistory(); }
-  if(tab==="settings"){ viewSettings.classList.add("active"); byId("appTitle").textContent="Impostazioni"; }
+  [viewTasks,viewCalendar,viewRank,viewSettings].forEach(v=>v.classList.remove('active'));
+  if(tab==='tasks'){ viewTasks.classList.add('active'); byId('appTitle').textContent='Pulizie di Casa'; }
+  if(tab==='calendar'){ viewCalendar.classList.add('active'); byId('appTitle').textContent='Calendario Pulizie'; renderCalendar(); }
+  if(tab==='rank'){ viewRank.classList.add('active'); byId('appTitle').textContent='Classifica'; renderLeader(); renderHistory(); }
+  if(tab==='settings'){ viewSettings.classList.add('active'); byId('appTitle').textContent='Impostazioni'; }
   currentTab = tab;
-  window.scrollTo({top:0,behavior:"smooth"});
+  updateNav(tab);
+  updateNavOffset();
+  window.scrollTo({top:0,behavior:'smooth'});
 }
-menuItems.forEach(b=> b.addEventListener("click", ()=>{ closeMenu(); switchView(b.dataset.tab); }));
+
+navTabs.forEach(b=> b.addEventListener('click', ()=> switchView(b.dataset.tab)));
+
+document.getElementById('mainNav').addEventListener('keydown', e=>{
+  if(!e.target.classList.contains('nav-tab')) return;
+  const tabs=Array.from(navTabs);
+  let idx=tabs.indexOf(e.target);
+  if(e.key==='ArrowRight'){ idx=(idx+1)%tabs.length; tabs[idx].focus(); e.preventDefault(); }
+  else if(e.key==='ArrowLeft'){ idx=(idx-1+tabs.length)%tabs.length; tabs[idx].focus(); e.preventDefault(); }
+  else if(e.key==='Enter' || e.key===' '){ e.preventDefault(); e.target.click(); }
+});
+
+function updateNavOffset(){
+  const h=document.getElementById('appHeader').offsetHeight;
+  document.documentElement.style.setProperty('--nav-height', h+'px');
+}
+window.addEventListener('resize', updateNavOffset);
+updateNavOffset();
 
 /* ===== Calendario ===== */
 const calGrid=byId("calGrid"), calTitle=byId("calTitle");


### PR DESCRIPTION
## Summary
- replace floating menu with sticky tab navigation
- style tabs for larger tap targets and theme contrast
- add keyboard navigation and safe-area offset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f12af6fc8320bbf3e008daa67a92