### PR TITLE
feat: add basic local backup service

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ window.importBackup(fileOrString); // importa i dati
 window.clearAllData(); // svuota lo storage
 ```
 
+## Backup locale automatico
+
+Il servizio di backup salva periodicamente tutti i dati dell'app in una cartella scelta dall'utente utilizzando la File System Access API (con fallback a OPFS).
+
+Funzioni disponibili nel contesto globale:
+
+```js
+requestBackupDir(); // permette di scegliere/autorizarre la cartella di backup
+importBackupFromDir(); // importa i dati da una cartella precedentemente esportata
+setBackupFrequency(days); // imposta la frequenza dell'export automatico
+```
+
 ## Foto delle pulizie
 
 Le immagini allegate alle pulizie vengono salvate in uno store dedicato (`attachments`).

--- a/main.js
+++ b/main.js
@@ -7,6 +7,9 @@ import {
   importBackup,
   clearAll
 } from "./src/storage/storage.js";
+import { runScheduledBackup, setBackupFrequency } from "./src/services/backupScheduler.ts";
+import { requestBackupDir, getOrRequestDir } from "./src/services/backupStorage.ts";
+import { importFromDirectory } from "./src/services/backupSerializer.ts";
 
 const loaderEl = document.getElementById("loaderOverlay");
 const mainEl = document.querySelector("main");
@@ -53,6 +56,7 @@ await initStorage();
 const persisted = await loadState();
 hideLoader();
 window.appState = persisted || {};
+runScheduledBackup();
 
 function triggerSave(reason) {
   if (!window.appState) return;
@@ -72,6 +76,12 @@ window.addEventListener("beforeunload", () => triggerSave("beforeunload"));
 window.exportBackup = exportBackup;
 window.importBackup = importBackup;
 window.clearAllData = clearAll;
+window.requestBackupDir = requestBackupDir;
+window.importBackupFromDir = async () => {
+  const dir = await getOrRequestDir();
+  if (dir) await importFromDirectory(dir, { merge: false });
+};
+window.setBackupFrequency = setBackupFrequency;
 
 function showUpdateToast() {
   if (document.getElementById("updateToast")) return;

--- a/src/services/backupScheduler.ts
+++ b/src/services/backupScheduler.ts
@@ -1,0 +1,24 @@
+import { getOrRequestDir, ensurePermissions } from './backupStorage.ts';
+import { exportToDirectory } from './backupSerializer.ts';
+import { get, upsert } from '../storage/storage.js';
+
+const DEFAULT_FREQ_DAYS = 7;
+
+export async function runScheduledBackup(){
+  const meta = await get('meta','backup') || {};
+  const freq = meta.freqDays || DEFAULT_FREQ_DAYS;
+  const last = meta.lastBackupAt || 0;
+  const dir = await ensurePermissions();
+  if(!dir) return; // no dir yet
+  const now = Date.now();
+  if(now - last < freq*86400000) return;
+  try{
+    await exportToDirectory(dir);
+    await upsert('meta',{id:'backup', lastBackupAt: now, freqDays: freq});
+  }catch(err){ console.error('auto backup failed', err); }
+}
+
+export async function setBackupFrequency(days:number){
+  const meta = await get('meta','backup') || {};
+  await upsert('meta',{id:'backup', lastBackupAt: meta.lastBackupAt||0, freqDays: days});
+}

--- a/src/services/backupSerializer.ts
+++ b/src/services/backupSerializer.ts
@@ -1,0 +1,42 @@
+import { loadState, upsert, clearAll } from '../storage/storage.js';
+import { sha256 } from '../utils/checksum.ts';
+
+export interface ManifestEntry{ path:string; hash:string; }
+export interface BackupManifest{ version:number; generatedAt:string; files: ManifestEntry[]; }
+
+export async function exportToDirectory(dir: FileSystemDirectoryHandle){
+  const state = await loadState();
+  const manifest: BackupManifest = { version:1, generatedAt:new Date().toISOString(), files:[] };
+  for(const [name, records] of Object.entries(state)){
+    const fileHandle = await dir.getFileHandle(`${name}.json`, {create:true});
+    const writable = await fileHandle.createWritable();
+    const text = JSON.stringify(records);
+    await writable.write(text);
+    await writable.close();
+    const hash = await sha256(text);
+    manifest.files.push({ path: `${name}.json`, hash });
+  }
+  const manifestHandle = await dir.getFileHandle('backup-manifest.json', {create:true});
+  const mw = await manifestHandle.createWritable();
+  await mw.write(JSON.stringify(manifest, null, 2));
+  await mw.close();
+  return manifest;
+}
+
+async function readJSON(file: File){
+  const text = await file.text();
+  return JSON.parse(text);
+}
+
+export async function importFromDirectory(dir: FileSystemDirectoryHandle, { merge = false } = {}){
+  const manifestFile = await dir.getFileHandle('backup-manifest.json').then(h=>h.getFile());
+  const manifest: BackupManifest = await readJSON(manifestFile);
+  if(!merge) await clearAll();
+  for(const entry of manifest.files){
+    const fh = await dir.getFileHandle(entry.path).then(h=>h.getFile());
+    const data = await readJSON(fh);
+    if(Array.isArray(data)){
+      for(const rec of data){ await upsert(entry.path.replace('.json',''), rec); }
+    }
+  }
+}

--- a/src/services/backupStorage.ts
+++ b/src/services/backupStorage.ts
@@ -1,0 +1,66 @@
+const DB_NAME = 'backup-storage';
+const STORE_NAME = 'handles';
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDB(){
+  if(dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve, reject)=>{
+    const req = indexedDB.open(DB_NAME,1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE_NAME);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+  return dbPromise;
+}
+
+async function saveHandle(handle: FileSystemDirectoryHandle){
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME,'readwrite');
+  tx.objectStore(STORE_NAME).put(handle,'backupDir');
+  return new Promise((res,rej)=>{tx.oncomplete=()=>res(undefined); tx.onerror=()=>rej(tx.error);});
+}
+
+async function loadHandle(): Promise<FileSystemDirectoryHandle|null>{
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME,'readonly');
+  const req = tx.objectStore(STORE_NAME).get('backupDir');
+  return new Promise((resolve)=>{
+    req.onsuccess = ()=> resolve(req.result || null);
+    req.onerror = ()=> resolve(null);
+  });
+}
+
+export async function requestBackupDir(){
+  if(!('showDirectoryPicker' in window)){
+    const opfs = await navigator.storage.getDirectory();
+    await saveHandle(opfs as unknown as FileSystemDirectoryHandle);
+    return opfs as unknown as FileSystemDirectoryHandle;
+  }
+  const handle = await (window as any).showDirectoryPicker({mode:'readwrite'});
+  await handle.requestPermission({mode:'readwrite'});
+  if(navigator.storage && (navigator.storage as any).persist){
+    try{ await (navigator.storage as any).persist(); }catch{}
+  }
+  await saveHandle(handle);
+  return handle;
+}
+
+export async function ensurePermissions(){
+  let handle = await loadHandle();
+  if(!handle) return null;
+  const perm = await (handle as any).queryPermission?.({mode:'readwrite'});
+  if(perm === 'granted') return handle;
+  if(perm === 'prompt'){
+    const res = await (handle as any).requestPermission?.({mode:'readwrite'});
+    if(res === 'granted') return handle;
+  }
+  return null;
+}
+
+export async function getOrRequestDir(){
+  const h = await ensurePermissions();
+  if(h) return h;
+  return requestBackupDir();
+}

--- a/src/utils/checksum.ts
+++ b/src/utils/checksum.ts
@@ -1,0 +1,11 @@
+export async function sha256(data: string | ArrayBuffer){
+  let buffer: ArrayBuffer;
+  if(typeof data === 'string'){
+    buffer = new TextEncoder().encode(data);
+  }else{
+    buffer = data;
+  }
+  const hash = await crypto.subtle.digest('SHA-256', buffer);
+  const arr = Array.from(new Uint8Array(hash));
+  return arr.map(b=>b.toString(16).padStart(2,'0')).join('');
+}

--- a/src/views/settings/DataBackup.js
+++ b/src/views/settings/DataBackup.js
@@ -1,0 +1,22 @@
+import { getOrRequestDir } from '../../services/backupStorage.ts';
+import { exportToDirectory, importFromDirectory } from '../../services/backupSerializer.ts';
+
+const freqSelect = document.getElementById('backupFrequency');
+const lastEl = document.getElementById('lastBackupInfo');
+const importDirBtn = document.getElementById('importFromDir');
+
+export async function initDataBackup(){
+  importDirBtn?.addEventListener('click', async()=>{
+    try{
+      const dir = await getOrRequestDir();
+      if(dir){ await exportToDirectory(dir); }
+    }catch(err){ console.error('backup failed', err); }
+  });
+}
+
+export async function doImportFromDirectory(){
+  if(!('showDirectoryPicker' in window)) return;
+  const dir = await (window as any).showDirectoryPicker({mode:'read'});
+  await importFromDirectory(dir,{merge:false});
+}
+


### PR DESCRIPTION
## Summary
- add services for requesting backup directory and handling permissions
- export/import state with manifest and checksum
- schedule automatic backups and expose helpers

## Testing
- `node scripts/dev-storage-smoke.mjs` (fails to exit automatically, manually interrupted after output)


------
https://chatgpt.com/codex/tasks/task_e_68a7306453fc83209a1e932af51f8ed4