### PR TITLE
Fix calendar layout on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,7 +344,7 @@ input::placeholder, textarea::placeholder{ color:var(--placeholder-color); }
 /* Calendario */
 .cal-toolbar{ display:flex; align-items:center; gap:8px; margin:8px 0 12px; }
 .cal-title{ font-weight:800; font-size:var(--fs-1); flex:1; text-align:center; }
-.cal-grid{ display:grid; grid-template-columns:repeat(7,1fr); gap:6px; }
+.cal-grid{ display:grid; grid-template-columns:repeat(7,1fr); gap:6px; width:100%; overflow-x:hidden; }
 .cal-dow{ text-align:center; font-weight:700; font-size:12px; opacity:.8; padding:6px 0; }
 .cal-cell{
   background:var(--surface-color); border:1px solid var(--border-color); border-radius:10px; padding:8px; min-height:64px; position:relative;
@@ -355,12 +355,12 @@ input::placeholder, textarea::placeholder{ color:var(--placeholder-color); }
   padding-right:24px; padding-top:2px; line-height:1;
 }
 .cal-badge{
-  position:absolute; top:4px; right:4px; z-index:2;
   font-size:11px; min-width:20px; min-height:20px; padding:0 6px;
   display:flex; align-items:center; justify-content:center;
   border-radius:999px; border:1px solid var(--border-color);
   background:var(--accent-color-2); color:var(--text-on-accent2);
   pointer-events:none;
+  align-self:center;
 }
 @media (max-width:359px){
   .cal-badge{ transform:scale(.85); font-size:10px; }


### PR DESCRIPTION
## Summary
- prevent horizontal scroll by constraining calendar grid to seven adaptive columns
- stack day number and cleaning badge vertically with the badge centered below the day

## Testing
- `node scripts/dev-storage-smoke.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68a811cee5808320955ff41c5b672e4b