### PR TITLE
Add visibility and periodic backup scheduling

### DIFF
--- a/src/services/backupScheduler.ts
+++ b/src/services/backupScheduler.ts
@@ -1,24 +1,69 @@
-import { getOrRequestDir, ensurePermissions } from './backupStorage.ts';
+import { ensurePermissions } from './backupStorage.ts';
 import { exportToDirectory } from './backupSerializer.ts';
 import { get, upsert } from '../storage/storage.js';
 
 const DEFAULT_FREQ_DAYS = 7;
+let schedulerInit = false;
 
-export async function runScheduledBackup(){
-  const meta = await get('meta','backup') || {};
-  const freq = meta.freqDays || DEFAULT_FREQ_DAYS;
-  const last = meta.lastBackupAt || 0;
-  const dir = await ensurePermissions();
-  if(!dir) return; // no dir yet
-  const now = Date.now();
-  if(now - last < freq*86400000) return;
-  try{
-    await exportToDirectory(dir);
-    await upsert('meta',{id:'backup', lastBackupAt: now, freqDays: freq});
-  }catch(err){ console.error('auto backup failed', err); }
+declare global {
+  interface ServiceWorkerRegistration {
+    periodicSync?: {
+      register(tag: string, options: { minInterval: number }): Promise<void>;
+    };
+  }
 }
 
-export async function setBackupFrequency(days:number){
-  const meta = await get('meta','backup') || {};
-  await upsert('meta',{id:'backup', lastBackupAt: meta.lastBackupAt||0, freqDays: days});
+async function tryRegisterPeriodicSync(freq: number): Promise<boolean> {
+  try {
+    if ('serviceWorker' in navigator) {
+      const reg = await navigator.serviceWorker.ready;
+      if (reg.periodicSync) {
+        await reg.periodicSync.register('cometa-backup', {
+          minInterval: freq * 86400000,
+        });
+        return true;
+      }
+    }
+  } catch (err) {
+    console.warn('periodicSync registration failed', err);
+  }
+  return false;
+}
+
+function setupVisibilityChecks() {
+  const check = () => {
+    runScheduledBackup();
+  };
+  window.addEventListener('focus', check);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') check();
+  });
+}
+
+export async function runScheduledBackup() {
+  const meta = (await get('meta', 'backup')) || {};
+  const freq = meta.freqDays || DEFAULT_FREQ_DAYS;
+
+  if (!schedulerInit) {
+    schedulerInit = true;
+    await tryRegisterPeriodicSync(freq);
+    setupVisibilityChecks();
+  }
+
+  const last = meta.lastBackupAt || 0;
+  const dir = await ensurePermissions();
+  if (!dir) return; // no dir yet
+  const now = Date.now();
+  if (now - last < freq * 86400000) return;
+  try {
+    await exportToDirectory(dir);
+    await upsert('meta', { id: 'backup', lastBackupAt: now, freqDays: freq });
+  } catch (err) {
+    console.error('auto backup failed', err);
+  }
+}
+
+export async function setBackupFrequency(days: number) {
+  const meta = (await get('meta', 'backup')) || {};
+  await upsert('meta', { id: 'backup', lastBackupAt: meta.lastBackupAt || 0, freqDays: days });
 }


### PR DESCRIPTION
## Summary
- attempt to register `navigator.periodicSync` for automated backups
- fall back to checking backups when app becomes active via `visibilitychange` and `focus`

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/Cometa-Cleaner/package.json')

------
https://chatgpt.com/codex/tasks/task_e_68a813b17c0083209845a7581d1eba88