### PR TITLE
Add backup configuration controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,6 +308,7 @@ input::placeholder, textarea::placeholder{ color:var(--placeholder-color); }
 }
 .file-btn input[type="file"]{ display:none; }
 .small-note{ font-size:12px; opacity:.7; margin-top:8px; }
+#lastBackupInfo{ font-size:12px; opacity:.7; margin-top:8px; }
 
 /* Toast */
 .toast-wrap{
@@ -544,6 +545,18 @@ input::placeholder, textarea::placeholder{ color:var(--placeholder-color); }
             <input type="file" id="restoreFile" accept="application/json">
           </label>
           <button id="clearDone" class="btn block">Cancella completate</button>
+        </div>
+        <div class="grid" style="margin-top:10px">
+          <button id="selectBackupDir" class="btn">Seleziona cartella</button>
+          <button id="importFromDir" class="btn">Importa da cartella</button>
+          <label class="field full">Frequenza backup
+            <select id="backupFrequency">
+              <option value="1">Ogni giorno</option>
+              <option value="7">Ogni settimana</option>
+              <option value="30">Ogni mese</option>
+            </select>
+          </label>
+          <div id="lastBackupInfo" class="full">Ultimo backup: mai</div>
         </div>
       </details>
       <details>

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ import {
 import { runScheduledBackup, setBackupFrequency } from "./src/services/backupScheduler.ts";
 import { requestBackupDir, getOrRequestDir } from "./src/services/backupStorage.ts";
 import { importFromDirectory } from "./src/services/backupSerializer.ts";
+import { initDataBackup } from "./src/views/settings/DataBackup.js";
 
 const loaderEl = document.getElementById("loaderOverlay");
 const mainEl = document.querySelector("main");
@@ -57,6 +58,7 @@ const persisted = await loadState();
 hideLoader();
 window.appState = persisted || {};
 runScheduledBackup();
+await initDataBackup();
 
 function triggerSave(reason) {
   if (!window.appState) return;


### PR DESCRIPTION
## Summary
- Fix import button to restore data from backup directory
- Add folder selection, backup frequency picker, and last backup info
- Wire backup settings initializer and update settings UI/CSS

## Testing
- `node --check src/views/settings/DataBackup.js`
- `node --check main.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a813a8b2c88320a82125a7ed0096a7