### PR TITLE
Use default initialization for backup settings

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ import {
 import { runScheduledBackup, setBackupFrequency } from "./src/services/backupScheduler.ts";
 import { requestBackupDir, getOrRequestDir } from "./src/services/backupStorage.ts";
 import { importFromDirectory } from "./src/services/backupSerializer.ts";
-import { initDataBackup } from "./src/views/settings/DataBackup.js";
+import initDataBackup from "./src/views/settings/DataBackup.js";
 
 const loaderEl = document.getElementById("loaderOverlay");
 const mainEl = document.querySelector("main");

--- a/src/views/settings/DataBackup.js
+++ b/src/views/settings/DataBackup.js
@@ -3,26 +3,32 @@ import { importFromDirectory } from '../../services/backupSerializer.ts';
 import { setBackupFrequency } from '../../services/backupScheduler.ts';
 import { get } from '../../storage/storage.js';
 
-const freqSelect = document.getElementById('backupFrequency');
-const lastEl = document.getElementById('lastBackupInfo');
-const importDirBtn = document.getElementById('importFromDir');
-const selectDirBtn = document.getElementById('selectBackupDir');
+export default async function initDataBackup(){
+  const freqSelect = document.getElementById('backupFrequency');
+  const lastEl = document.getElementById('lastBackupInfo');
+  const importDirBtn = document.getElementById('importFromDir');
+  const selectDirBtn = document.getElementById('selectBackupDir');
 
-export async function initDataBackup(){
-  importDirBtn?.addEventListener('click', async()=>{
-    try{
-      await doImportFromDirectory();
-    }catch(err){ console.error('import failed', err); }
-  });
+  if(importDirBtn){
+    importDirBtn.addEventListener('click', async()=>{
+      try{
+        await doImportFromDirectory();
+      }catch(err){ console.error('import failed', err); }
+    });
+  }
 
-  selectDirBtn?.addEventListener('click', async()=>{
-    try{ await requestBackupDir(); }catch(err){ console.error('select dir failed', err); }
-  });
+  if(selectDirBtn){
+    selectDirBtn.addEventListener('click', async()=>{
+      try{ await requestBackupDir(); }catch(err){ console.error('select dir failed', err); }
+    });
+  }
 
-  freqSelect?.addEventListener('change', async()=>{
-    const days = parseInt((freqSelect as HTMLSelectElement).value,10);
-    if(!isNaN(days)) await setBackupFrequency(days);
-  });
+  if(freqSelect){
+    freqSelect.addEventListener('change', async()=>{
+      const days = parseInt((freqSelect as HTMLSelectElement).value,10);
+      if(!isNaN(days)) await setBackupFrequency(days);
+    });
+  }
 
   const meta = await get('meta','backup') || {};
   if(freqSelect && meta.freqDays) (freqSelect as HTMLSelectElement).value = String(meta.freqDays);


### PR DESCRIPTION
## Summary
- Guard backup settings event listeners by ensuring DOM elements exist
- Expose a default `initDataBackup` initializer and invoke it from `main.js`
- Import directories using `doImportFromDirectory` on button click

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a818dfed508320bf257d029ca3f174