### PR TITLE
Refactor backup settings UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -528,24 +528,12 @@ input::placeholder, textarea::placeholder{ color:var(--placeholder-color); }
       </details>
       <details>
         <summary>Dati &amp; Backup</summary>
-        <div class="grid-compact" style="margin-top:10px">
-          <button id="exportTasks" class="btn block">Esporta pulizie</button>
-          <label class="file-btn">Importa pulizie
-            <input type="file" id="importTasks" accept="application/json">
-          </label>
-          <button id="exportMyScore" class="btn block">Esporta classifica (utente attivo)</button>
-          <label class="file-btn">Importa classifica su utente attivo
-            <input type="file" id="importMyScore" accept="application/json">
-          </label>
-          <button id="backup" class="btn block">Backup completo</button>
-          <label class="file-btn">Ripristina backup completo
-            <input type="file" id="restoreFile" accept="application/json">
-          </label>
-          <button id="clearDone" class="btn block">Cancella completate</button>
-        </div>
         <div class="grid" style="margin-top:10px">
           <button id="selectBackupDir" class="btn">Seleziona cartella</button>
           <button id="importFromDir" class="btn">Importa da cartella</button>
+          <label class="file-btn">Importa da ZIP
+            <input type="file" id="importFromZip" accept="application/zip">
+          </label>
           <label class="field full">Frequenza backup
             <select id="backupFrequency">
               <option value="1">Ogni giorno</option>
@@ -1625,66 +1613,6 @@ const remindAt=byId("remindAt"), resurface=byId("resurface");
 remindAt.value = state.settings.remindAt||"09:00"; resurface.checked = !!state.settings.resurfaceUnfinished;
 remindAt.addEventListener("change", ()=>{ const v=remindAt.value.trim(); if(/^\d{2}:\d{2}$/.test(v)){ state.settings.remindAt=v; save(); showToast("⏰ Ora promemoria aggiornata"); } else { alert("Usa HH:MM"); remindAt.value=state.settings.remindAt||"09:00"; } });
 resurface.addEventListener("change", ()=>{ state.settings.resurfaceUnfinished=resurface.checked; save(); showToast(resurface.checked?"🧼 Riproponi attivo":"🧼 Riproponi disattivato"); });
-
-/* Export/Import parziali */
-const exportTasksBtn=byId("exportTasks");
-const importTasksInput=byId("importTasks");
-const exportMyScoreBtn=byId("exportMyScore");
-const importMyScoreInput=byId("importMyScore");
-exportTasksBtn.addEventListener("click", ()=>{
-  const payload = JSON.stringify({version: state.version, tasks: state.tasks}, null, 2);
-  const file=new File([payload],"pulizie-tasks-"+todayYMD()+".json",{type:"application/json"});
-  const a=document.createElement("a"); a.href=URL.createObjectURL(file); a.download=file.name; a.click(); URL.revokeObjectURL(a.href);
-  showToast("⬇️ Esportate solo le pulizie");
-});
-importTasksInput.addEventListener("change", async (e)=>{
-  const f=e.target.files[0]; if(!f) return;
-  try{
-    const data=JSON.parse(await f.text());
-    if(Array.isArray(data.tasks)){ state.tasks=data.tasks; save(); renderTasks(); renderCalendar(); showToast("✅ Pulizie importate"); }
-    else alert("File non valido (manca 'tasks').");
-  }catch(err){ alert("Import non riuscito: "+err); }
-  e.target.value="";
-});
-exportMyScoreBtn.addEventListener("click", ()=>{
-  const uid=state.activeUserId, name = (state.users.find(u=>u.id===uid)||{}).name || "utente";
-  const payload = JSON.stringify({userId: uid, userName: name, score: state.score[uid]||0, history: state.history.filter(h=>h.userId===uid)}, null, 2);
-  const file=new File([payload],`classifica-${name.replace(/\s+/g,'_')}.json`,{type:"application/json"});
-  const a=document.createElement("a"); a.href=URL.createObjectURL(file); a.download=file.name; a.click(); URL.revokeObjectURL(a.href);
-  showToast("⬇️ Esportata classifica utente attivo");
-});
-importMyScoreInput.addEventListener("change", async (e)=>{
-  const f=e.target.files[0]; if(!f) return;
-  try{
-    const data=JSON.parse(await f.text());
-    const uid=state.activeUserId;
-    if(typeof data.score==="number"){
-      state.score[uid]=data.score;
-      if(Array.isArray(data.history)){ state.history = state.history.concat(data.history.map(h=>({...h, userId:uid, userName:(state.users.find(u=>u.id===uid)||{}).name||h.userName, reason:(h.reason||"import")+" (import)"}))); }
-      save(); renderLeader(); renderHistory(); showToast("✅ Classifica aggiornata (utente attivo)");
-    }else{
-      alert("File non valido (manca 'score').");
-    }
-  }catch(err){ alert("Import non riuscito: "+err); }
-  e.target.value="";
-});
-
-/* Backup completo */
-byId("backup").addEventListener("click", ()=>{ const payload=JSON.stringify(state,null,2); const file=new File([payload],"pulizie-backup-"+todayYMD()+".json",{type:"application/json"}); const a=document.createElement("a"); a.href=URL.createObjectURL(file); a.download=file.name; a.click(); URL.revokeObjectURL(a.href); showToast("💾 Backup completo creato"); });
-const restoreFile = document.getElementById("restoreFile");
-restoreFile.addEventListener("change", async (e)=>{
-  const f = e.target.files[0];
-  if(!f) return;
-  try{
-    state = migrate(JSON.parse(await f.text()));
-    save(); boot(); showToast("🧰 Ripristino completo");
-  }catch(err){
-    alert("Ripristino non riuscito: " + err);
-  }finally{
-    e.target.value = "";
-  }
-});
-byId("clearDone").addEventListener("click", ()=>{ state.tasks=state.tasks.filter(t=>!t.done); save(); renderTasks(); renderCalendar(); showToast("🧹 Completate cancellate"); });
 
 /* ===== Navigazione Menù ===== */
 const viewTasks=byId("viewTasks"), viewCalendar=byId("viewCalendar"), viewRank=byId("viewRank"), viewSettings=byId("viewSettings");

--- a/src/views/settings/DataBackup.js
+++ b/src/views/settings/DataBackup.js
@@ -1,40 +1,79 @@
-import { getOrRequestDir, requestBackupDir } from '../../services/backupStorage.ts';
-import { importFromDirectory } from '../../services/backupSerializer.ts';
-import { setBackupFrequency } from '../../services/backupScheduler.ts';
+import { ensurePermissions } from '../../services/backupStorage.ts';
 import { get } from '../../storage/storage.js';
 
 const freqSelect = document.getElementById('backupFrequency');
 const lastEl = document.getElementById('lastBackupInfo');
 const importDirBtn = document.getElementById('importFromDir');
 const selectDirBtn = document.getElementById('selectBackupDir');
+const importZipInput = document.getElementById('importFromZip');
 
 export async function initDataBackup(){
   importDirBtn?.addEventListener('click', async()=>{
     try{
-      await doImportFromDirectory();
+      await (window as any).importBackupFromDir?.();
+      await refreshLastInfo();
     }catch(err){ console.error('import failed', err); }
   });
 
   selectDirBtn?.addEventListener('click', async()=>{
-    try{ await requestBackupDir(); }catch(err){ console.error('select dir failed', err); }
+    try{ await (window as any).requestBackupDir?.(); await refreshLastInfo(); }
+    catch(err){ console.error('select dir failed', err); }
+  });
+
+  importZipInput?.addEventListener('change', async (e)=>{
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if(!file) return;
+    try{
+      await (window as any).importBackup?.(file);
+      await refreshLastInfo();
+    }catch(err){ console.error('zip import failed', err); }
+    (e.target as HTMLInputElement).value = '';
   });
 
   freqSelect?.addEventListener('change', async()=>{
     const days = parseInt((freqSelect as HTMLSelectElement).value,10);
-    if(!isNaN(days)) await setBackupFrequency(days);
+    if(!isNaN(days)) await (window as any).setBackupFrequency?.(days);
   });
 
   const meta = await get('meta','backup') || {};
   if(freqSelect && meta.freqDays) (freqSelect as HTMLSelectElement).value = String(meta.freqDays);
-  if(lastEl){
-    lastEl.textContent = meta.lastBackupAt
-      ? `Ultimo backup: ${new Date(meta.lastBackupAt).toLocaleString()}`
-      : 'Ultimo backup: mai';
-  }
+  await refreshLastInfo(meta);
 }
 
-export async function doImportFromDirectory(){
-  const dir = await getOrRequestDir();
-  if(dir){ await importFromDirectory(dir,{merge:false}); }
+async function refreshLastInfo(meta?: any){
+  if(!lastEl) return;
+  meta = meta || await get('meta','backup') || {};
+  let text = 'Ultimo backup: mai';
+  if(meta.lastBackupAt){
+    let sizeStr = '';
+    try{
+      const dir = await ensurePermissions();
+      if(dir){
+        const total = await dirSize(dir);
+        sizeStr = ` (${formatBytes(total)})`;
+      }
+    }catch(err){ console.warn('size calc failed', err); }
+    text = `Ultimo backup: ${new Date(meta.lastBackupAt).toLocaleString()}${sizeStr}`;
+  }
+  lastEl.textContent = text;
+}
+
+async function dirSize(dir: any): Promise<number>{
+  let total = 0;
+  for await (const [, handle] of (dir as any).entries()){
+    if(handle.kind === 'file'){
+      const f = await handle.getFile();
+      total += f.size;
+    }else if(handle.kind === 'directory'){
+      total += await dirSize(handle);
+    }
+  }
+  return total;
+}
+
+function formatBytes(bytes:number){
+  if(bytes >= 1048576) return (bytes/1048576).toFixed(1) + ' MB';
+  if(bytes >= 1024) return (bytes/1024).toFixed(1) + ' KB';
+  return bytes + ' B';
 }
 


### PR DESCRIPTION
## Summary
- streamline backup settings by removing legacy export/import buttons
- add directory and ZIP import controls with backup frequency selector
- show last backup date and size using global helpers

## Testing
- `node scripts/dev-storage-smoke.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68a818e3a5a48320abaecae625ff4454