### PR TITLE
Fix grid-compact button sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,8 @@ input::placeholder, textarea::placeholder{ color:var(--placeholder-color); }
 .grid-compact > .btn,
 .grid-compact > .file-btn{
   width:100%;
-  aspect-ratio:1/1;
+  min-height:44px;
+  padding:8px 12px;
   display:flex;
   align-items:center;
   justify-content:center;


### PR DESCRIPTION
## Summary
- remove square aspect ratio from compact grid buttons
- align compact grid button padding and min-height with other buttons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a818e959d48320adce1758736b7f98