### PR TITLE
Fix today tab task detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -972,9 +972,10 @@ function statusForTask(t){
   const start=parseLocal(t.startAt);
   if(!start) return { next:null, code: t.done?"done":"future" };
   const next=t.repeat?.enabled ? nextOccurrenceFromStart(start, t.repeat.every, t.repeat.unit, now, t.repeat.weekdays||[]) : start;
+  const occursToday = occursOnDay(t, now);
   if(t.done) return { next, code:"done" };
   if(!next) return { next:null, code:"future" };
-  if(isSameDay(next, now)) return { next, code:"due" };
+  if(occursToday) return { next, code:"due" };
   if(next < now) return { next, code:"over" };
   return { next, code:"future" };
 }


### PR DESCRIPTION
## Summary
- ensure the "Oggi" tab checks whether a cleaning task occurs today instead of comparing the next occurrence with the current timestamp, so cleanings scheduled earlier in the day appear in the list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d905e32f0832089527141ce7b11ce)