### PR TITLE
Add firebase config folder instructions

### DIFF
--- a/ios/firebase/README.md
+++ b/ios/firebase/README.md
@@ -1,0 +1,16 @@
+# Firebase iOS Config Files
+
+Posiziona qui il file `GoogleService-Info.plist` scaricato dalla console Firebase per la build iOS di Cometa Cleaner.
+
+## Come aggiungere il file
+1. Accedi alla console Firebase → **Project settings** → scheda dell'app iOS e scarica `GoogleService-Info.plist`.
+2. Copia il file in questa cartella con il nome originale: `ios/firebase/GoogleService-Info.plist`.
+3. Se vuoi versionarlo, aggiungilo a Git:
+   ```bash
+   git add ios/firebase/GoogleService-Info.plist
+   git commit -m "Add Firebase iOS config"
+   ```
+   > In alternativa, aggiungi il file alla `.gitignore` se preferisci distribuirlo tramite un canale sicuro.
+4. Quando apri il progetto in Xcode, trascina il file dal percorso `ios/firebase/GoogleService-Info.plist` nel target dell'app e assicurati che sia incluso in **Copy Bundle Resources**.
+
+Seguendo queste istruzioni tutti i collaboratori sapranno dove trovare il file di configurazione iOS di Firebase.


### PR DESCRIPTION
## Summary
- create a dedicated `ios/firebase` directory for Firebase configuration files
- document how to download, place, and optionally version `GoogleService-Info.plist` for the iOS build

## Testing
- not run; documentation-only changes

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68b8541a56148320898038052e2b81f9)