### PR TITLE
Improve desktop layout styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,8 +102,11 @@ header{
 header .top-bar{
   position:relative;
   display:flex; align-items:center; justify-content:space-between; gap:10px;
-  padding:calc(10px + var(--safe-top)) 12px 10px;
+  padding:calc(10px + var(--safe-top)) 16px 12px;
   min-height:44px;
+  width:100%;
+  max-width:1200px;
+  margin:0 auto;
 }
 .logo{width:40px;height:40px;border-radius:8px;object-fit:contain;border:1px solid var(--border-color); background:var(--accent-color);position:absolute;left:50%;transform:translate(-50%,-8px);}
 #viewRank,#viewSettings{padding-top:10px;}
@@ -112,10 +115,10 @@ header .top-bar{
   #toggleFilters{order:1;}
   #addTaskBtn{order:2;}
 }
-.nav-tabs{position:relative; display:flex; overflow-x:auto; scroll-snap-type:x mandatory; background:var(--nav-bg); color:var(--nav-fg);}
+.nav-tabs{position:relative; display:flex; overflow-x:auto; scroll-snap-type:x mandatory; background:var(--nav-bg); color:var(--nav-fg); gap:6px; padding:0 12px; max-width:1200px; margin:0 auto; align-items:stretch;} 
 .nav-tabs::-webkit-scrollbar{display:none;}
 .nav-tabs::before,.nav-tabs::after{content:""; position:absolute; top:0; bottom:0; width:12px; pointer-events:none;}
-.nav-tabs::before{left:0; background:linear-gradient(to right,var(--nav-bg),transparent);}
+.nav-tabs::before{left:0; background:linear-gradient(to right,var(--nav-bg),transparent);} 
 .nav-tabs::after{right:0; background:linear-gradient(to left,var(--nav-bg),transparent);}
 .nav-tab{position:relative; flex:0 0 auto; display:flex; align-items:center; gap:8px; padding:0 16px; min-height:56px; font-size:16px; font-weight:500; line-height:1.3; background:none; border:none; color:inherit; cursor:pointer; scroll-snap-align:start;}
 .nav-tab .icon{width:20px; height:20px; flex:0 0 20px;}
@@ -125,8 +128,9 @@ header .top-bar{
 .nav-tab.active::after{content:""; position:absolute; left:12px; right:12px; bottom:0; height:2px; background:var(--nav-indicator); border-radius:2px;}
 @media(max-width:359px){.nav-tab{padding:0 10px; font-size:14px;}}
 @media(min-width:600px){.nav-tab{flex:1; justify-content:center;}}
-.container{max-width:860px; margin:0 auto; padding:12px; display:flex; flex-direction:column; min-height:calc(100svh - var(--nav-height)); min-height:calc(100dvh - var(--nav-height));}
-.view{display:none; flex-direction:column; flex:1;}
+.container{max-width:860px; margin:0 auto; padding:12px; display:flex; flex-direction:column; min-height:calc(100svh - var(--nav-height)); min-height:calc(100dvh - var(--nav-height)); width:100%; gap:10px;}
+.tabs{display:flex; gap:8px; margin:6px 0 10px; flex-wrap:wrap}
+.view{display:none; flex-direction:column; flex:1; gap:8px;}
 .view.active{display:flex;}
 #viewTasks{min-height:0;}
 ul#list{list-style:none; padding:0; margin:0; flex:1; display:flex; flex-direction:column; gap:var(--space-8);}
@@ -276,6 +280,21 @@ input::placeholder, textarea::placeholder{ color:var(--placeholder-color); }
   border-radius:12px;
   border:1px solid var(--border-color);
   object-fit:cover;
+}
+
+@media(min-width:900px){
+  .logo{ position:static; transform:none; margin:0 auto; width:48px; height:48px; }
+  header .top-bar{ padding:calc(14px + var(--safe-top)) 24px 14px; gap:16px; }
+  header .top-bar .icon-btn{ min-width:44px; }
+  .nav-tabs{ justify-content:center; overflow:visible; padding:0 24px 6px; gap:12px; }
+  .nav-tabs::before,.nav-tabs::after{ display:none; }
+  .nav-tab{ flex:0 0 auto; border-radius:999px; border:1px solid var(--border-color); background:var(--surface-color); box-shadow:var(--shadow); min-width:140px; }
+  .nav-tab.active{ box-shadow:0 8px 26px rgba(0,0,0,.08); }
+  .nav-tab.active::after{ left:0; right:0; bottom:-1px; height:3px; }
+  main.container{ max-width:1100px; padding:24px 24px 32px; gap:16px; }
+  .tabs{ margin-top:0; }
+  ul#list{ padding-right:4px; }
+  li.task{ margin:12px 0; }
 }
 
 /* Classifica */


### PR DESCRIPTION
## Summary
- refine header and navigation spacing to center content on desktop without overlaps
- allow tabs and views to wrap cleanly with added spacing and wider desktop container

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209ae7dc7c83209127f3d19af9f091)